### PR TITLE
update app url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a canonical app for 3factor which showcases the three factors in detail 
 
 You can preview the apps at the following links:
 
-**order-app** : [3factor.hasura.app/order-app](https://3factor.hasura.app/order-app)
+**order-app** : [https://serverless-demo.hasura.app/order-app](https://serverless-demo.hasura.app/order-app)
 
-**analytics-app** : [3factor.hasura.app/analytics-app](https://3factor.hasura.app/analytics-app)
+**analytics-app** : [https://serverless-demo.hasura.app/analytics-app](https://serverless-demo.hasura.app/analytics-app)
 
 You can follow along this step-by-step guide to deploy and evaluate this application design pattern yourself.
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This is a canonical app for 3factor which showcases the three factors in detail with a reference implementation. The reference implementation is a food ordering app which has a user facing component (order-app) and an admin dashboard (analytics-app).
 
-You can preview the apps at the following links:
-
-**order-app** : [https://serverless-demo.hasura.app/order-app](https://serverless-demo.hasura.app/order-app)
-
-**analytics-app** : [https://serverless-demo.hasura.app/analytics-app](https://serverless-demo.hasura.app/analytics-app)
-
 You can follow along this step-by-step guide to deploy and evaluate this application design pattern yourself.
 
 ## What is a 3Factor App?


### PR DESCRIPTION
The old URL [3factor.hasura.app](https://3factor.hasura.app) is deprecated. It is now moved to [serverless-demo.hasura.app](https://serverless-demo.hasura.app). The README has been updated to reflect the same.